### PR TITLE
Make the query "in-<column>:<value>" be case-insensitive to the value

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -323,7 +323,11 @@ void LookupIndexKey(
           break;
         }
 
-        if (string_view::npos == row_key.find(parameter)) continue;
+        if (row_key.end() == std::search(row_key.begin(),
+          row_key.end(), parameter.begin(), parameter.end(),
+          [] (const auto &c1, const auto &c2) {
+            return std::tolower(c1) == std::tolower(c2); }
+          )) continue;
 
         ca_offset_score_parse(data, &new_offsets);
 


### PR DESCRIPTION
It's a pity that proper UTF-8 case folding is prohibitively complex.
