### PR TITLE
V1.5

### DIFF
--- a/src/ca-load.cc
+++ b/src/ca-load.cc
@@ -111,7 +111,7 @@ struct option kLongOptions[] = {
     {"help", no_argument, &print_help, 1},
     {0, 0, 0, 0}};
 
-std::unique_ptr<ca_table::Table> table_handle;
+std::unique_ptr<ca_table::TableBuilder> table_handle;
 
 enum token_state {
   parse_key,
@@ -540,7 +540,7 @@ void MergeSummariesCallback(std::string key,
   table_handle->InsertRow(key, merged);
 }
 
-void CopyTable(ca_table::Table* input, ca_table::Table* output) {
+void CopyTable(ca_table::Table* input, ca_table::TableBuilder* output) {
   cantera::string_view key, value;
 
   while (input->ReadRow(key, value)) {

--- a/src/ca-table.h
+++ b/src/ca-table.h
@@ -30,23 +30,9 @@ struct ca_offset_score;
 class Query;
 class Schema;
 class Table;
-class SeekableTable;
-class TableOptions;
 
 // Escape string for use in tab delimited format.
 std::string Escape(const string_view& str);
-
-class Backend {
- public:
-  virtual ~Backend();
-
-  virtual std::unique_ptr<Table> Create(const char* path,
-                                        const TableOptions &options) = 0;
-
-  virtual std::unique_ptr<Table> Open(const char* path) = 0;
-
-  virtual std::unique_ptr<SeekableTable> OpenSeekable(const char* path) = 0;
-};
 
 void LookupKey(const std::vector<Table*>& index_tables,
                const char* key,
@@ -152,10 +138,6 @@ struct ca_score {
   float score_pct75 = std::numeric_limits<float>::quiet_NaN();
   float score_pct95 = std::numeric_limits<float>::quiet_NaN();
 };
-
-/*****************************************************************************/
-
-Backend* ca_table_backend(const char* name);
 
 /*****************************************************************************/
 
@@ -297,6 +279,22 @@ class SeekableTable : public Table {
 
   virtual void Seek(off_t offset, int whence) = 0;
 };
+
+/*****************************************************************************/
+
+class Backend {
+ public:
+  virtual ~Backend();
+
+  virtual std::unique_ptr<Table> Create(const char* path,
+                                        const TableOptions &options) = 0;
+
+  virtual std::unique_ptr<Table> Open(const char* path) = 0;
+
+  virtual std::unique_ptr<SeekableTable> OpenSeekable(const char* path) = 0;
+};
+
+Backend* ca_table_backend(const char* name);
 
 /*****************************************************************************/
 

--- a/src/ca-table.h
+++ b/src/ca-table.h
@@ -298,10 +298,6 @@ class SeekableTable : public Table {
   virtual void Seek(off_t offset, int whence) = 0;
 };
 
-int ca_table_stat(Table* table, struct stat* buf);
-
-int ca_table_utime(Table* table, const struct timeval tv[2]);
-
 /*****************************************************************************/
 
 class TableFactory {

--- a/src/table-backend-leveldb-table.cc
+++ b/src/table-backend-leveldb-table.cc
@@ -121,11 +121,7 @@ class LevelDBReader : public leveldb::RandomAccessFile {
     return leveldb::Status::OK();
   }
 
-  uint64_t FileSize() const {
-    off_t size;
-    KJ_SYSCALL(size = lseek(fd_, 0, SEEK_END));
-    return size;
-  }
+  uint64_t FileSize() const { return cantera::table::internal::FileSize(fd_); }
 
  private:
   kj::AutoCloseFd fd_;

--- a/src/table-backend-leveldb-table.cc
+++ b/src/table-backend-leveldb-table.cc
@@ -53,8 +53,6 @@
 # define fdatasync fsync
 #endif
 
-#define TMP_SUFFIX ".tmp.XXXXXX"
-
 #define CHECK_STATUS(expr)                                       \
   do {                                                           \
     auto status = (expr);                                        \
@@ -101,37 +99,11 @@ class LevelDBWriter : public PendingFile, public leveldb::WritableFile {
   }
 };
 
-class LevelDBReader : public leveldb::RandomAccessFile {
- public:
-  LevelDBReader(const char* path) : fd_(OpenFile(path, O_RDONLY | O_CLOEXEC)) {}
-
-  ~LevelDBReader() noexcept(true) {
-    try {
-      fd_ = nullptr;
-    } catch (...) {
-    }
-  }
-
-  leveldb::Status Read(uint64_t offset, size_t n, leveldb::Slice* result,
-                       char* scratch) const override {
-    auto amount_read = pread(fd_, scratch, n, offset);
-    if (amount_read < 0)
-      return leveldb::Status::IOError("pread failed", strerror(errno));
-    *result = leveldb::Slice(scratch, static_cast<size_t>(n));
-    return leveldb::Status::OK();
-  }
-
-  uint64_t FileSize() const { return cantera::table::internal::FileSize(fd_); }
-
- private:
-  kj::AutoCloseFd fd_;
-};
-
 /*****************************************************************************/
 
-class LevelDBTable : public Table, public TableBuilder {
+class LevelDBBuilder : public TableBuilder {
  public:
-  LevelDBTable(const char* path, const TableOptions& options) {
+  LevelDBBuilder(const char* path, const TableOptions& options) {
     leveldb::Options leveldb_options;
     switch (options.GetCompression()) {
       case kTableCompressionNone:
@@ -141,7 +113,8 @@ class LevelDBTable : public Table, public TableBuilder {
         leveldb_options.compression = leveldb::kSnappyCompression;
         break;
       default:
-        KJ_FAIL_REQUIRE("LevelDB tables do not support given compression method");
+        KJ_FAIL_REQUIRE(
+            "LevelDB tables do not support given compression method");
     }
 
     writable_file_ = std::make_unique<LevelDBWriter>(
@@ -150,12 +123,36 @@ class LevelDBTable : public Table, public TableBuilder {
         leveldb_options, writable_file_.get());
   }
 
-  LevelDBTable(const char* path) {
-    file_ = std::make_unique<LevelDBReader>(path);
+  void Sync() override {
+    CHECK_STATUS(table_builder_->Finish());
+    writable_file_->Finish();
+  }
 
+  void InsertRow(const string_view& key, const string_view& value) override {
+    KJ_REQUIRE(prev_key_ <= key, "keys inserted out of order", prev_key_,
+               std::string(key));
+    table_builder_->Add(leveldb::Slice(key.data(), key.size()),
+                        leveldb::Slice(value.data(), value.size()));
+    prev_key_ = std::string(key);
+    CHECK_STATUS(table_builder_->status());
+  }
+
+ private:
+  std::unique_ptr<LevelDBWriter> writable_file_;
+  std::unique_ptr<leveldb::TableBuilder> table_builder_;
+
+  // Used to ensure rows are inserted in lexicographical order.
+  std::string prev_key_;
+};
+
+/*****************************************************************************/
+
+class LevelDBTable : public Table, private leveldb::RandomAccessFile {
+ public:
+  LevelDBTable(const char* path) : fd_(OpenFile(path, O_RDONLY | O_CLOEXEC)) {
     leveldb::Table* table;
-    CHECK_STATUS(leveldb::Table::Open(leveldb::Options(), file_.get(),
-                                      file_->FileSize(), &table));
+    CHECK_STATUS(
+        leveldb::Table::Open(leveldb::Options(), this, FileSize(fd_), &table));
     table_.reset(table);
 
     iterator_.reset(table_->NewIterator(leveldb::ReadOptions()));
@@ -163,18 +160,14 @@ class LevelDBTable : public Table, public TableBuilder {
     if (!iterator_->Valid()) eof_ = true;
   }
 
-  void Sync() override {
-    KJ_REQUIRE(table_builder_ != nullptr);
-    CHECK_STATUS(table_builder_->Finish());
-    writable_file_->Finish();
+  ~LevelDBTable() noexcept {
+    try {
+      fd_ = nullptr;
+    } catch (...) {
+    }
   }
 
   int IsSorted() override { return true; }
-
-  void InsertRow(const string_view& key, const string_view& value) override {
-    Add(leveldb::Slice(key.data(), key.size()),
-        leveldb::Slice(value.data(), value.size()));
-  }
 
   void SeekToFirst() override {
     iterator_->SeekToFirst();
@@ -207,21 +200,7 @@ class LevelDBTable : public Table, public TableBuilder {
                    const_cast<const void**>(&value->iov_base), &value->iov_len);
   }
 
-  void Add(const leveldb::Slice& key, const leveldb::Slice& value) {
-    KJ_REQUIRE(table_builder_ != nullptr);
-    auto key_begin = reinterpret_cast<const uint8_t*>(key.data());
-    auto key_end = key_begin + key.size();
-    if (!std::lexicographical_compare(prev_key_.begin(), prev_key_.end(),
-                                      key_begin, key_end)) {
-      KJ_FAIL_REQUIRE("keys inserted out of order",
-                      std::string(prev_key_.begin(), prev_key_.end()),
-                      std::string(key_begin, key_end));
-    }
-    table_builder_->Add(key, value);
-    prev_key_.assign(key_begin, key_end);
-    CHECK_STATUS(table_builder_->status());
-  }
-
+ private:
   bool SeekToKey(const leveldb::Slice& key) {
     KJ_REQUIRE(iterator_ != nullptr);
 
@@ -263,16 +242,16 @@ class LevelDBTable : public Table, public TableBuilder {
     return true;
   }
 
- private:
-  // Writing
-  std::unique_ptr<LevelDBWriter> writable_file_;
-  std::unique_ptr<leveldb::TableBuilder> table_builder_;
+  leveldb::Status Read(uint64_t offset, size_t n, leveldb::Slice* result,
+                       char* scratch) const override {
+    auto amount_read = pread(fd_, scratch, n, offset);
+    if (amount_read < 0)
+      return leveldb::Status::IOError("pread failed", strerror(errno));
+    *result = leveldb::Slice(scratch, static_cast<size_t>(n));
+    return leveldb::Status::OK();
+  }
 
-  // Used to ensure rows are inserted in lexicographical order.
-  std::vector<uint8_t> prev_key_;
-
-  // Reading
-  std::unique_ptr<LevelDBReader> file_;
+  kj::AutoCloseFd fd_;
   std::unique_ptr<leveldb::Table> table_;
   std::unique_ptr<leveldb::Iterator> iterator_;
   bool need_seek_ = false;
@@ -283,7 +262,7 @@ class LevelDBTable : public Table, public TableBuilder {
 
 std::unique_ptr<TableBuilder> LevelDBTableBackend::Create(
     const char* path, const TableOptions& options) {
-  return std::make_unique<LevelDBTable>(path, options);
+  return std::make_unique<LevelDBBuilder>(path, options);
 }
 
 std::unique_ptr<Table> LevelDBTableBackend::Open(const char* path) {

--- a/src/table-backend-leveldb-table.h
+++ b/src/table-backend-leveldb-table.h
@@ -11,9 +11,11 @@ class LevelDBTableBackend : public Backend {
   std::unique_ptr<TableBuilder> Create(const char* path,
                                        const TableOptions& options) override;
 
-  std::unique_ptr<Table> Open(const char* path) override;
+  std::unique_ptr<Table> Open(const char* path, int fd,
+                              const struct stat& st) override;
 
-  std::unique_ptr<SeekableTable> OpenSeekable(const char* path) override;
+  std::unique_ptr<SeekableTable> OpenSeekable(const char* path, int fd,
+                                              const struct stat& st) override;
 };
 
 }  // namespace table

--- a/src/table-backend-leveldb-table.h
+++ b/src/table-backend-leveldb-table.h
@@ -8,8 +8,8 @@ namespace table {
 
 class LevelDBTableBackend : public Backend {
  public:
-  std::unique_ptr<Table> Create(const char* path,
-                                const TableOptions& options) override;
+  std::unique_ptr<TableBuilder> Create(const char* path,
+                                       const TableOptions& options) override;
 
   std::unique_ptr<Table> Open(const char* path) override;
 

--- a/src/table-backend-writeonce.h
+++ b/src/table-backend-writeonce.h
@@ -8,8 +8,8 @@ namespace table {
 
 class WriteOnceTableBackend : public Backend {
  public:
-  std::unique_ptr<Table> Create(const char* path,
-                                const TableOptions& options) override;
+  std::unique_ptr<TableBuilder> Create(const char* path,
+                                       const TableOptions& options) override;
 
   std::unique_ptr<Table> Open(const char* path) override;
 

--- a/src/table-backend-writeonce.h
+++ b/src/table-backend-writeonce.h
@@ -11,9 +11,11 @@ class WriteOnceTableBackend : public Backend {
   std::unique_ptr<TableBuilder> Create(const char* path,
                                        const TableOptions& options) override;
 
-  std::unique_ptr<Table> Open(const char* path) override;
+  std::unique_ptr<Table> Open(const char* path, int fd,
+                              const struct stat& st) override;
 
-  std::unique_ptr<SeekableTable> OpenSeekable(const char* path) override;
+  std::unique_ptr<SeekableTable> OpenSeekable(const char* path, int fd,
+                                              const struct stat& st) override;
 };
 
 }  // namespace table

--- a/src/table-write.cc
+++ b/src/table-write.cc
@@ -34,7 +34,7 @@
 namespace cantera {
 namespace table {
 
-void ca_table_write_offset_score(Table* table,
+void ca_table_write_offset_score(TableBuilder* table,
                                  const string_view& key,
                                  const struct ca_offset_score* values,
                                  size_t count) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -31,6 +31,12 @@ kj::AutoCloseFd AnonTemporaryFile(const char* path, int mode) {
   return TemporaryFile(path, 0, mode, true);
 }
 
+off_t FileSize(int fd) {
+  struct stat st;
+  KJ_SYSCALL(fstat(fd, &st));
+  return st.st_size;
+}
+
 /*****************************************************************************/
 
 TemporaryFile::~TemporaryFile() noexcept {

--- a/src/util.h
+++ b/src/util.h
@@ -22,6 +22,8 @@ kj::AutoCloseFd OpenFile(const char* path, int flags, int mode = 0666);
 kj::AutoCloseFd AnonTemporaryFile(const char* path = nullptr,
                                   int mode = S_IRUSR | S_IWUSR);
 
+off_t FileSize(int fd);
+
 size_t ReadWithOffset(int fd, void* dest, size_t size_min, size_t size_max,
                       off_t offset);
 

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 #include <experimental/string_view>
 
 #include <fcntl.h>
@@ -47,8 +48,8 @@ class TemporaryFile : public kj::AutoCloseFd {
 
   void Unlink() {
 #if !defined(O_TMPFILE)
-    if (!temp_path_.empty()) {
-      KJ_SYSCALL(unlink(temp_path_.data()), temp_path_);
+    if (temp_path_) {
+      KJ_SYSCALL(unlink(temp_path_.get()), temp_path_.get());
       Reset();
     }
 #endif
@@ -58,9 +59,9 @@ class TemporaryFile : public kj::AutoCloseFd {
 
  protected:
 #if !defined(O_TMPFILE)
-  void Reset() { temp_path_.clear(); }
+  void Reset() { temp_path_.reset(); }
 
-  std::string temp_path_;
+  std::unique_ptr<char[]> temp_path_;
 #endif
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -69,6 +69,8 @@ class PendingFile : public TemporaryFile {
  public:
   PendingFile(const char* path, int flags, mode_t mode);
 
+  const std::string& path() const { return path_; }
+
   void Finish();
 
  private:


### PR DESCRIPTION
Another massive refactoring. Both leveldb-table and write-once backends are in fact write-once. Tables and indexes are built with ca-load. It never has both reads and writes for the same table/index at the same time. 

So the API was changed to reflect this fact. Now TableBuilder is a separate object. This allowed to simplify the internals, drop recurring checks of the Table state -- whether it is now reading or inserting rows.

Also plugged a race condition between table format detection and its real opening. However slim the chance for a race is, it's not nice to have one.

And finally write-once backend now uses anonymous temporary files too.

There are some rough edges though. It would be great to make this one the last interface change in a while. So if there are any objections or suggestions let's address them here.
